### PR TITLE
Update Arduino-usbserial.c

### DIFF
--- a/firmwares/atmega16u2/arduino-usbserial/Arduino-usbserial.c
+++ b/firmwares/atmega16u2/arduino-usbserial/Arduino-usbserial.c
@@ -161,8 +161,8 @@ int main(void)
 			{
 				// SAM3X RESET/ERASE Sequence
 				// --------------------------
-				// Between 60 and 120: do erase
-				if (ResetTimer >= 60 && ResetTimer <= 120) {
+				// Between 60 and 120: do erase, 60 count = 250ms
+				if (ResetTimer >= 60 && ResetTimer <= 180) {
 					setErasePin(true);
 				} else {
 					setErasePin(false);
@@ -300,7 +300,7 @@ void EVENT_CDC_Device_ControLineStateChanged(USB_ClassInfo_CDC_Device_t* const C
 
 	if (Selected1200BPS) {
 		/* Start Erase / Reset procedure when receiving the magic "1200" baudrate */
-		ResetTimer = 120;
+		ResetTimer = 180;
 	} else if (!PreviousDTRState && CurrentDTRState) {
 		/* Reset on rising edge of DTR */
 		ResetTimer = 50;


### PR DESCRIPTION
Fix the unusable programming port by making the erase time longer (250ms->500ms). 
According to the datasheet, the recommended erase time is greater than 220ms. In most cases the original program should be OK. However, in my case, the uploading is almost 90% fail rate (Device not found at comx port...). But I can manually press the erase button before the uploading, and it works well. After the proposed changes, the programming port works as expected and I no longer necessary to hit the erase button.